### PR TITLE
allow multiple recognition events (or manual entry) without overwriting/sending

### DIFF
--- a/public/contentScript.js
+++ b/public/contentScript.js
@@ -8,16 +8,18 @@ if (window.location.href === 'https://chat.openai.com/chat') {
 	let transcript = '';
 	var recognition = new webkitSpeechRecognition();
 	recognition.continuous = false;
-	recognition.interimResults = true;
+	recognition.interimResults = false;
 
 	let recognizing = false;
 	recognition.onstart = function () {
 		textArea.parentElement.style.borderColor = 'red';
-		textArea.value = '';
+		//textArea.value = '';
 		recognizing = true;
 		transcript = '';
 	};
 	recognition.onresult = function (event) {
+		// Get the current value of the text area
+		var enteredText = textArea.value;
 		transcript = '';
 		for (var i = event.resultIndex; i < event.results.length; ++i) {
 			transcript += event.results[i][0].transcript;
@@ -26,12 +28,13 @@ if (window.location.href === 'https://chat.openai.com/chat') {
 		textArea.value = transcript;
 		let ev = new Event('input', { bubbles: true});
         	textArea.dispatchEvent(ev);
+		textArea.value = enteredText + " " + transcript;
 	};
 	recognition.onend = function () {
 		textArea.parentElement.style.borderColor = 'lightgray';
 		recognizing = false;
 		transcript = '';
-		textArea.parentElement.querySelector('button').click();
+		//textArea.parentElement.querySelector('button').click();
 	};
 	recognition.onerror = function (event) {
 		console.log('error', event);


### PR DESCRIPTION
Recognition often ends before I'm done speaking if I have to stop and think. Previously, that would immediately send the output to ChatGPT, often confusing it with dictation errors or truncated text. This PR disables the parentElement click onend, and instead allows for multiple recognition events (just type tab again), or manual editing/entry of text. New recognition events currently go at the end of the textArea.value, not at the cursor. I had to disable recognition.interimResults to avoid concatenating all of the interimResults together. It would be helpful to figure out how to re-enable recognition.interimResults, and to have recognition-entered text go where the cursor is, but IMO this is an improvement as-is without those.